### PR TITLE
Restructure packages into "main" and "ruter"

### DIFF
--- a/ruter/ruter.go
+++ b/ruter/ruter.go
@@ -1,4 +1,4 @@
-package sanntid
+package ruter
 
 import (
 	"fmt"
@@ -22,12 +22,11 @@ type sanntidArrivalData struct {
 	MonitoredVehicleJourney sanntidMonitoredVehicleJourney
 }
 
-func requestArrivalData(locationId int) ([]sanntidArrivalData, error) {
+func RequestArrivalData(locationId int) ([]sanntidArrivalData, error) {
 	var data []sanntidArrivalData
 
 	url := fmt.Sprintf("http://reisapi.ruter.no/stopvisit/getdepartures/%d", locationId)
 	res, err := goreq.Request{ Uri: url }.Do()
-
 	if err == nil {
 		res.Body.FromJsonTo(&data)
 	}

--- a/sanntid.go
+++ b/sanntid.go
@@ -1,4 +1,8 @@
-package sanntid
+package main
+
+import (
+	"github.com/michaelenger/sanntid/ruter"
+)
 
 type Line struct {
 	Name string
@@ -14,7 +18,7 @@ type Arrival struct {
 func GetArrivals(locationId int) ([]Arrival, error) {
 	var arrivals []Arrival
 
-	data, err := requestArrivalData(locationId)
+	data, err := ruter.RequestArrivalData(locationId)
 
 	if err == nil {
 		for i,j := 0,0; i < len(data); i,j = i+1,j+1 {


### PR DESCRIPTION
As far as I understand it, every "thing" (Go package, repository etc.) should
have a "main" package. I'm mostly going by example[1], where all the files at
the root are in "main" package, and all files in sub directories have their own
package.

It also makes it convenient when developing locally, as `go run main.go` expects
the entry point to be main:main (`main` function in `main` package).

`RequestArrivalData` is renamed with a capital R, as that makes it a public
function apparently[2]:

 > In Go if something starts with a capital letter that means other packages
 > (and programs) are able to see it

In reality, I just did this because I didn't realise soon enough that you had to
pass multiple files to `go run` to make it compile correctly with all the
functions exported.

[1]:https://github.com/hashicorp/terraform
[2]:http://www.golang-book.com/11/index.htm#section1