### PR TITLE
Rewrite requestArrivalData

### DIFF
--- a/ruter.go
+++ b/ruter.go
@@ -2,7 +2,9 @@ package sanntid
 
 import (
 	"fmt"
-	"github.com/franela/goreq"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
 )
 
 type sanntidMonitoredCall struct {
@@ -26,11 +28,19 @@ func requestArrivalData(locationId int) ([]sanntidArrivalData, error) {
 	var data []sanntidArrivalData
 
 	url := fmt.Sprintf("http://reisapi.ruter.no/stopvisit/getdepartures/%d", locationId)
-	res, err := goreq.Request{ Uri: url }.Do()
 
-	if err == nil {
-		res.Body.FromJsonTo(&data)
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
 	}
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	json.Unmarshal(body, &data)
 
 	return data, err
 }

--- a/ruter.go
+++ b/ruter.go
@@ -20,14 +20,18 @@ type sanntidMonitoredVehicleJourney struct {
 	VehicleMode int
 }
 
-type sanntidArrivalData struct {
+// ArrivalData cointains the parsed data returned from a request to
+// Ruter's API.
+type ArrivalData struct {
 	MonitoredVehicleJourney sanntidMonitoredVehicleJourney
 }
 
-func requestArrivalData(locationId int) ([]sanntidArrivalData, error) {
-	var data []sanntidArrivalData
+// RequestArrivalData retrieves information about the upcoming arrivals for
+// a given location based on its locationId.
+func RequestArrivalData(locationID int) ([]ArrivalData, error) {
+	var data []ArrivalData
 
-	url := fmt.Sprintf("http://reisapi.ruter.no/stopvisit/getdepartures/%d", locationId)
+	url := fmt.Sprintf("http://reisapi.ruter.no/stopvisit/getdepartures/%d", locationID)
 
 	resp, err := http.Get(url)
 	if err != nil {

--- a/ruter.go
+++ b/ruter.go
@@ -22,14 +22,14 @@ type sanntidMonitoredVehicleJourney struct {
 
 // ArrivalData cointains the parsed data returned from a request to
 // Ruter's API.
-type ArrivalData struct {
+type sanntidArrivalData struct {
 	MonitoredVehicleJourney sanntidMonitoredVehicleJourney
 }
 
 // RequestArrivalData retrieves information about the upcoming arrivals for
 // a given location based on its locationId.
-func RequestArrivalData(locationID int) ([]ArrivalData, error) {
-	var data []ArrivalData
+func requestArrivalData(locationID int) ([]sanntidArrivalData, error) {
+	var data []sanntidArrivalData
 
 	url := fmt.Sprintf("http://reisapi.ruter.no/stopvisit/getdepartures/%d", locationID)
 

--- a/sanntid.go
+++ b/sanntid.go
@@ -14,7 +14,7 @@ type Arrival struct {
 func GetArrivals(locationId int) ([]Arrival, error) {
 	var arrivals []Arrival
 
-	data, err := RequestArrivalData(locationId)
+	data, err := requestArrivalData(locationId)
 
 	if err == nil {
 		for i,j := 0,0; i < len(data); i,j = i+1,j+1 {

--- a/sanntid.go
+++ b/sanntid.go
@@ -14,7 +14,7 @@ type Arrival struct {
 func GetArrivals(locationId int) ([]Arrival, error) {
 	var arrivals []Arrival
 
-	data, err := requestArrivalData(locationId)
+	data, err := RequestArrivalData(locationId)
 
 	if err == nil {
 		for i,j := 0,0; i < len(data); i,j = i+1,j+1 {


### PR DESCRIPTION
Rewrites most of the functionality around `requestArrivalData`. We now only use built in packages, so we don't need to rely on any third party libraries.

I've also ensured it adheres to the Golint rules. The tools is written by the Golang people, so I guess we should try to adhere to it as much as possible? Still quite a few places which throws errors.

~~This includes the changes in #1, so it would be wise to merge that first.~~