### PR TITLE
Directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ data, err := sanntid.GetArrivals(3010536)
 
 ### API
 
-#### `GetArrivals(int) ([]Arrival, error)`
+#### `GetArrivals(int, sanntidDirection) ([]Arrival, error)`
 
 Retrieve the arrivals for a specific location based on the location ID, which can be found in the [Ruter API](http://labs.trafikanten.no/how-to-use-the-api.aspx). It returns a slice of `Arrival` type or an `error` if an error occurred.
 
 ```go
-data, err := sanntid.GetArrivals(3010536)
+data, err := sanntid.GetArrivals(3010536, sanntid.DirAny)
 
 if err == nil {
 	for i := 0; i < len(data); i++ {
@@ -61,6 +61,7 @@ type Arrival struct {
 type Line struct {
 	Name string
 	Destination string
+	Direction sanntidDirection
 }
 ```
 

--- a/ruter.go
+++ b/ruter.go
@@ -7,6 +7,10 @@ import (
 	"net/http"
 )
 
+// sanntidDirection defines the direction of the vehicle. It is either,
+// 0 (undefined (?)), 1 or 2.
+type sanntidDirection int
+
 type sanntidMonitoredCall struct {
 	ExpectedArrivalTime   string
 	DeparturePlatformName string
@@ -18,7 +22,7 @@ type sanntidMonitoredVehicleJourney struct {
 	MonitoredCall     sanntidMonitoredCall
 	PublishedLineName string
 	VehicleMode       int
-	DirectionRef      int `json:",string"`
+	DirectionRef      sanntidDirection `json:",string"`
 }
 
 // ArrivalData cointains the parsed data returned from a request to

--- a/ruter.go
+++ b/ruter.go
@@ -18,6 +18,7 @@ type sanntidMonitoredVehicleJourney struct {
 	MonitoredCall     sanntidMonitoredCall
 	PublishedLineName string
 	VehicleMode       int
+	DirectionRef      int `json:",string"`
 }
 
 // ArrivalData cointains the parsed data returned from a request to

--- a/sanntid.go
+++ b/sanntid.go
@@ -3,6 +3,7 @@ package sanntid
 type Line struct {
 	Name        string
 	Destination string
+	Direction   int
 }
 
 type Arrival struct {
@@ -21,6 +22,7 @@ func GetArrivals(locationId int) ([]Arrival, error) {
 			line := Line{
 				data[i].MonitoredVehicleJourney.PublishedLineName,
 				data[i].MonitoredVehicleJourney.DestinationName,
+				data[i].MonitoredVehicleJourney.DirectionRef,
 			}
 			arrival := Arrival{
 				line,

--- a/sanntid.go
+++ b/sanntid.go
@@ -1,9 +1,20 @@
 package sanntid
 
+const (
+	// DirAny will give you Line in any direction.
+	DirAny sanntidDirection = iota
+
+	// DirUp will give you Line in only one direction.
+	DirUp
+
+	// DirDown will give you Line in only one direction, reverse of DirUp.
+	DirDown
+)
+
 type Line struct {
 	Name        string
 	Destination string
-	Direction   int
+	Direction   sanntidDirection
 }
 
 type Arrival struct {
@@ -12,25 +23,28 @@ type Arrival struct {
 	Platform            string
 }
 
-func GetArrivals(locationId int) ([]Arrival, error) {
+func GetArrivals(locationId int, direction sanntidDirection) ([]Arrival, error) {
 	var arrivals []Arrival
 
 	data, err := requestArrivalData(locationId)
 
 	if err == nil {
 		for i := 0; i < len(data); i++ {
-			line := Line{
-				data[i].MonitoredVehicleJourney.PublishedLineName,
-				data[i].MonitoredVehicleJourney.DestinationName,
-				data[i].MonitoredVehicleJourney.DirectionRef,
-			}
-			arrival := Arrival{
-				line,
-				data[i].MonitoredVehicleJourney.MonitoredCall.ExpectedArrivalTime,
-				data[i].MonitoredVehicleJourney.MonitoredCall.DeparturePlatformName,
-			}
+			lineDir := data[i].MonitoredVehicleJourney.DirectionRef
+			if direction == DirAny || direction == lineDir {
+				line := Line{
+					data[i].MonitoredVehicleJourney.PublishedLineName,
+					data[i].MonitoredVehicleJourney.DestinationName,
+					lineDir,
+				}
+				arrival := Arrival{
+					line,
+					data[i].MonitoredVehicleJourney.MonitoredCall.ExpectedArrivalTime,
+					data[i].MonitoredVehicleJourney.MonitoredCall.DeparturePlatformName,
+				}
 
-			arrivals = append(arrivals, arrival)
+				arrivals = append(arrivals, arrival)
+			}
 		}
 	}
 


### PR DESCRIPTION
We should expose some information about which direction the vehicle is heading and probably also allow for some sort of filtering, so we only get arrivals in a certain directions.

Turns out this isn't as easy to implement as I thought. Firstly, where does the directional data belong. On the arrival or the line? I put it on `Line` now, as I thought it kinda made sense, but I feel it could belong to the `Arrival` as well.

Ruter's API isn't very well documented around this either. The API exposes both `DirectionName` and `DirectionRef`. They always seems to be the same, and are either `"1"`, `"2"` or `null`. It starts out with either 1 or 2, then the remaining are always `null` it seems. They also always seem to be integers, but are formatted as strings for some reason.

And what kind of API should we expose for directions? Something like west/east, north/south, 0/1, 1/2, up/down? 